### PR TITLE
Fix compile error with rust 1.34.2

### DIFF
--- a/src/rw/snapshot.rs
+++ b/src/rw/snapshot.rs
@@ -12,7 +12,7 @@ use std::collections::hash_map::{HashMap, Entry};
 use byteorder::{ByteOrder, BigEndian, WriteBytesExt};
 
 use elt::Element;
-use error::{Result, ReadError, ElementOp};
+use error::{Result, ReadError, ElementOp, OtherError};
 use rw::{sum, read_meta, write_meta};
 use state::{PartState, StateRead};
 use sum::{Sum, SUM_BYTES};


### PR DESCRIPTION
I've looking at pippin and needed this to compile it on the version on rust I'm using.