### PR TITLE
Save state with pippincmd 

### DIFF
--- a/examples/pippincmd.rs
+++ b/examples/pippincmd.rs
@@ -332,6 +332,8 @@ fn inner(path: PathBuf, op: Operation, args: Rest) -> Result<()>
                         state.remove(id.into())?;
                     },
                 }
+                part.push_state(state)?;
+                part.write_full()?;
             }       // destroy reference `state`
             
             let has_changes = part.write_fast()?;

--- a/src/rw/snapshot.rs
+++ b/src/rw/snapshot.rs
@@ -12,7 +12,7 @@ use std::collections::hash_map::{HashMap, Entry};
 use byteorder::{ByteOrder, BigEndian, WriteBytesExt};
 
 use elt::Element;
-use error::{Result, ReadError, ElementOp};
+use error::{Result, ReadError, ElementOp, OtherError};
 use rw::{sum, read_meta, write_meta};
 use state::{PartState, StateRead};
 use sum::{Sum, SUM_BYTES};


### PR DESCRIPTION
I found pippincmd -e ELTID PATH, wasn't saving state.

I tried:
```
cargo run --example hello
cargo run --example hello

cargo run --example pippincmd -- -g ELT_ID ./
cargo run --example pippincmd -- -e ELT_ID ./
cargo run --example pippincmd -- -g ELT_ID ./
```
where ELT_ID was the element_Id created by the hello example, and despite changing the content
in my editor the '-g'/get commands still returned the same content without this patch.

I've pretty much just copied what the 'hello' example did to save state, so it might not be quite right, but it does work.
