### PR TITLE
Pippincmd  Edit (-e) doesn't create elements as per usage .

### DIFF
--- a/examples/pippincmd.rs
+++ b/examples/pippincmd.rs
@@ -332,6 +332,8 @@ fn inner(path: PathBuf, op: Operation, args: Rest) -> Result<()>
                         state.remove(id.into())?;
                     },
                 }
+                part.push_state(state)?;
+                part.write_full()?;
             }       // destroy reference `state`
             
             let has_changes = part.write_fast()?;

--- a/src/rw/snapshot.rs
+++ b/src/rw/snapshot.rs
@@ -12,7 +12,7 @@ use std::collections::hash_map::{HashMap, Entry};
 use byteorder::{ByteOrder, BigEndian, WriteBytesExt};
 
 use elt::Element;
-use error::{Result, ReadError, ElementOp};
+use error::{Result, ReadError, ElementOp, OtherError};
 use rw::{sum, read_meta, write_meta};
 use state::{PartState, StateRead};
 use sum::{Sum, SUM_BYTES};


### PR DESCRIPTION
I found if running something like:
```
cargo run --example pippincmd --  -e 1 test_spc/
``` 
in a new space then pippincmd would panic with "element not found", but the usage documents it as creating the element specifically saying " If ELT does not exist, it will be created.", this patch implements this behaviour.

BTW; I'm a newbie with rust so apologies if this is rust baby-talk ;-)